### PR TITLE
fix(http_client, conversation): propagate chat_id and stop X-Chat-ID header bleed across calls

### DIFF
--- a/grinning_cat_python_sdk/clients/http_client.py
+++ b/grinning_cat_python_sdk/clients/http_client.py
@@ -36,23 +36,30 @@ class HttpClient:
 
         return urlunparse((scheme, netloc, "", "", "", ""))
 
+    def _set_or_drop_header(self, name: str, value: str | None) -> None:
+        """Set the header when a value is provided, otherwise drop any stale value.
+
+        `self.headers` is reused across calls, so a previous value would leak
+        into the next request when the new call passes ``None`` for the same
+        identifier (agent_id / user_id / chat_id).
+        """
+        if value:
+            self.headers[name] = value
+        else:
+            self.headers.pop(name, None)
+
     def __before_secure_request(self):
         if self.apikey:
             self.headers["Authorization"] = f"Bearer {self.apikey}"
-        if self.agent_id:
-            self.headers["X-Agent-ID"] = self.agent_id
-        if self.user_id:
-            self.headers["X-User-ID"] = self.user_id
-        if self.chat_id:
-            self.headers["X-Chat-ID"] = self.chat_id
+        self._set_or_drop_header("X-Agent-ID", self.agent_id)
+        self._set_or_drop_header("X-User-ID", self.user_id)
+        self._set_or_drop_header("X-Chat-ID", self.chat_id)
 
     def __before_jwt_request(self):
         if self.token:
             self.headers["Authorization"] = f"Bearer {self.token}"
-        if self.agent_id:
-            self.headers["X-Agent-ID"] = self.agent_id
-        if self.chat_id:
-            self.headers["X-Chat-ID"] = self.chat_id
+        self._set_or_drop_header("X-Agent-ID", self.agent_id)
+        self._set_or_drop_header("X-Chat-ID", self.chat_id)
 
     def get_client(
         self,
@@ -63,6 +70,9 @@ class HttpClient:
         if not self.apikey and not self.token:
             raise ValueError("You must provide an apikey or a token")
 
+        # Reset header dict each call so stale values from a previous
+        # request cannot leak into the next session.
+        self.headers = {}
         self.agent_id = agent_id
         self.user_id = user_id
         self.chat_id = chat_id

--- a/grinning_cat_python_sdk/endpoints/conversation.py
+++ b/grinning_cat_python_sdk/endpoints/conversation.py
@@ -27,6 +27,7 @@ class ConversationEndpoint(AbstractEndpoint):
             self.format_url(f"{chat_id}/history"),
             agent_id,
             user_id=user_id,
+            chat_id=chat_id,
             output_class=ConversationHistoryOutput,
         )
 
@@ -55,6 +56,7 @@ class ConversationEndpoint(AbstractEndpoint):
             self.format_url(chat_id),
             agent_id,
             user_id=user_id,
+            chat_id=chat_id,
             output_class=ConversationsResponse,
         )
 
@@ -71,6 +73,7 @@ class ConversationEndpoint(AbstractEndpoint):
             agent_id,
             output_class=ConversationDeleteOutput,
             user_id=user_id,
+            chat_id=chat_id,
         )
 
     def put_conversation_attributes(
@@ -105,4 +108,5 @@ class ConversationEndpoint(AbstractEndpoint):
             output_class=ConversationAttributesChangeOutput,
             payload=payload,
             user_id=user_id,
+            chat_id=chat_id,
         )


### PR DESCRIPTION
## Problem

Two bugs combine to make every call after the first one address the wrong chat / user / agent:

1. **`ConversationEndpoint` drops `chat_id`.**
   `get_conversation_history`, `get_conversation`, `delete_conversation` and `put_conversation_attributes` embed `chat_id` only in the URL path and **do not** forward it to the underlying `self.get / self.put / self.delete` call. As a result `HttpClient.get_client` is invoked with `chat_id=None` and `self.chat_id` is reset to `None` on the shared `HttpClient` instance.

2. **`HttpClient` never drops stale headers.**
   `__before_secure_request` and `__before_jwt_request` only **add** headers when the corresponding identifier is truthy — they never **remove** them. `self.headers` is a long-lived dict on the instance, so after one call sets `X-Chat-ID = A`, the next call with `chat_id=None` keeps `X-Chat-ID = A` in the dict. Same problem for `X-Agent-ID` and `X-User-ID`.

## Symptom

`grinning-cat-core` resolves the chat from the `X-Chat-ID` header (header wins over path param in `cat.auth.auth_utils._extract_key_from_request`). Iterating over a user's conversations and calling `get_conversation_history(chat_id=A)` then `(chat_id=B)` therefore returns the working memory history of `A` for **both** calls. In our instructor dashboard two conversations of the same user end up showing identical messages even though the DB stores them correctly as distinct.

## Fix

- Forward `chat_id` to the underlying HTTP method in all four `ConversationEndpoint` methods.
- In `HttpClient` introduce `_set_or_drop_header` so each middleware sets the header when a value is provided and pops any stale value when `None`.
- Reset `self.headers = {}` at the start of `get_client` to avoid any other leftover from previous requests.

## Files changed

- `grinning_cat_python_sdk/clients/http_client.py`
- `grinning_cat_python_sdk/endpoints/conversation.py`
